### PR TITLE
chore(ci): update Codecov GitHub action to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build koverVerify koverXmlReport
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: ${{ github.workspace }}/build/reports/kover/report.xml
         env:


### PR DESCRIPTION
Upgrade codecov/codecov-action from v3 to v5 in the CI workflow for improved support and features.