### PR TITLE
chore(ci): update main.yml to restrict publish job to manual triggers…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,15 @@ name: CI
 # Continuous Integration workflow for the Central Portal Publisher Gradle plugin
 # 
 # Triggers:
-# - Push to main branch: Runs build + automatic publish
-# - Pull requests: Runs build only for validation
-# - Manual trigger: Runs build + optional publish (user checkbox)
+# - Push to main branch: Runs build and validation only
+# - Pull requests: Runs build and validation
+# - Manual trigger: Runs build + optional publish for testing (user checkbox)
 #
 # Jobs:
 # - build: Validates code quality, runs tests, generates coverage
-# - publish: Deploys plugin to Gradle Plugin Portal (conditional)
+# - publish: Deploys plugin to Gradle Plugin Portal (manual testing only)
+#
+# Note: Production releases are handled by release.yml workflow
 
 on:
   workflow_dispatch:
@@ -58,12 +60,12 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # Publish plugin to Gradle Plugin Portal
-  # Only runs on main branch pushes or manual triggers with publish=true
+  # Publish plugin to Gradle Plugin Portal (for testing only)
+  # Only runs on manual triggers with publish=true (not on main branch pushes)
   publish:
     runs-on: ubuntu-latest
     needs: build
-    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    if: github.event_name == 'workflow_dispatch' && inputs.publish
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
  Updated Workflow Strategy:

  main.yml (CI Workflow):

  - ✅ Main/PR pushes: Build + validation only (no publishing)
  - ✅ Manual trigger: Build + optional publish for testing purposes
  - ✅ Focuses on code quality and validation

  release.yml (Release Workflow):

  - ✅ Manual trigger with version: Full release process
  - ✅ Creates git tags and GitHub releases
  - ✅ Publishes to Gradle Plugin Portal for production

  Benefits:

  1. No accidental releases - Main branch commits don't trigger releases
  2. Controlled releases - Only via release.yml with explicit version
  3. Testing capability - Can still test publish via main.yml manual trigger
  4. Clean git history - Tags only created for actual releases

  Usage:

  # Development workflow
  git push origin main  # → Only runs CI validation

  # Testing publish (optional)
  # Actions → CI → Run workflow → ☑️ Publish checkbox

  # Production release
  # Actions → Release → Run workflow → Input: 1.0.0

  This is the industry standard approach used by major projects - CI validates, dedicated release workflow publishes.
